### PR TITLE
perf(db): add indexes for article listing queries

### DIFF
--- a/db/migrations/00010101000002_add_articles_listing_indexes.sql
+++ b/db/migrations/00010101000002_add_articles_listing_indexes.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+CREATE INDEX IF NOT EXISTS idx_articles_published_at_desc
+    ON articles (published_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_articles_read_published_at_desc
+    ON articles (read, published_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_articles_bookmarked_published_at_desc
+    ON articles (bookmarked, published_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_articles_bookmarked_published_at_desc;
+DROP INDEX IF EXISTS idx_articles_read_published_at_desc;
+DROP INDEX IF EXISTS idx_articles_published_at_desc;


### PR DESCRIPTION
### Motivation
- Improve query performance for the main article listing pages and filtered views by speeding up ordering and boolean-filtered lookups (e.g. unread/bookmarked and next-unread).

### Description
- Add reversible migration `db/migrations/00010101000002_add_articles_listing_indexes.sql` which creates `idx_articles_published_at_desc`, `idx_articles_read_published_at_desc`, and `idx_articles_bookmarked_published_at_desc`, and drops them in the `migrate:down` section.

### Testing
- Ran `make lint` (golangci-lint) which completed successfully.
- Ran `make test` (calls `go test ./...`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee143dd50483328cb31007581047ba)