### PR TITLE
feat: decouple feed fetching from article release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A personal newsreader.
 - **Read articles** in a clean, distraction-free interface
 - Manually **mark articles as read**, without doom-scrolling
 - **Bookmark articles** for later
-- **Auto-update feeds** on a schedule, no slot machine pull-to-refresh
+- **Fetch feeds regularly** while releasing new articles only at scheduled times
 - **Dark mode** for those late-night reading sessions
 - **Self-hosted**: no ads, no tracking, no paywalls
 - **No JavaScript**: just server-rendered HTML
@@ -43,8 +43,10 @@ The configuration file is a JSON file with the structure shown below.
   "base_url": "http://localhost:8080",
   // Port to listen on
   "port": 8080,
-  // Times to update feeds
-  "update_times": [
+  // How often to fetch feeds (defaults to 60 minutes)
+  "fetch_interval_minutes": 60,
+  // Times when fetched articles become visible
+  "release_times": [
     7,
     16
   ],
@@ -68,6 +70,13 @@ The configuration file is a JSON file with the structure shown below.
   }
 }
 ```
+
+`release_times` uses whole hours in the server's local timezone. Automatically fetched articles remain hidden
+until the next configured release time, when all waiting articles become visible. If no release times are configured,
+automatic fetching is disabled. Manual feed fetches and articles ingested by URL are visible immediately.
+
+For backwards compatibility, `update_times` is accepted as a deprecated alias for `release_times`. If both are
+configured, `release_times` takes precedence.
 
 ## Screenshots
 

--- a/app/config.go
+++ b/app/config.go
@@ -5,16 +5,20 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/cugu/fomo/feed"
 )
 
 type Config struct {
-	BaseURL     string
-	Port        int
-	Feeds       []feed.Feed
-	UpdateTimes []int
+	BaseURL       string
+	Port          int
+	Feeds         []feed.Feed
+	ReleaseTimes  []int
+	FetchInterval time.Duration
 }
+
+const defaultFetchInterval = time.Hour
 
 func parseConfig(configPath string) (*Config, error) {
 	slog.Info("Loading config", "path", configPath)
@@ -33,11 +37,13 @@ func parseConfig(configPath string) (*Config, error) {
 }
 
 type JSONConfig struct {
-	BaseURL     string                     `json:"base_url"`
-	Password    string                     `json:"password"`
-	Port        int                        `json:"port"`
-	Feeds       map[string]json.RawMessage `json:"feeds"`
-	UpdateTimes []int                      `json:"update_times"`
+	BaseURL              string                     `json:"base_url"`
+	Password             string                     `json:"password"`
+	Port                 int                        `json:"port"`
+	Feeds                map[string]json.RawMessage `json:"feeds"`
+	ReleaseTimes         []int                      `json:"release_times"`
+	UpdateTimes          []int                      `json:"update_times"`
+	FetchIntervalMinutes int                        `json:"fetch_interval_minutes"`
 }
 
 type TypedConfig struct {
@@ -45,6 +51,31 @@ type TypedConfig struct {
 }
 
 func (j *JSONConfig) toConfig() (*Config, error) {
+	feeds, err := j.parseFeeds()
+	if err != nil {
+		return nil, err
+	}
+
+	releaseTimes, err := j.parseReleaseTimes()
+	if err != nil {
+		return nil, err
+	}
+
+	fetchInterval, err := j.parseFetchInterval()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		BaseURL:       j.BaseURL,
+		Port:          j.Port,
+		Feeds:         feeds,
+		ReleaseTimes:  releaseTimes,
+		FetchInterval: fetchInterval,
+	}, nil
+}
+
+func (j *JSONConfig) parseFeeds() ([]feed.Feed, error) {
 	var feeds []feed.Feed
 
 	for name, raw := range j.Feeds {
@@ -66,10 +97,38 @@ func (j *JSONConfig) toConfig() (*Config, error) {
 		feeds = append(feeds, feed)
 	}
 
-	return &Config{
-		BaseURL:     j.BaseURL,
-		Port:        j.Port,
-		Feeds:       feeds,
-		UpdateTimes: j.UpdateTimes,
-	}, nil
+	return feeds, nil
+}
+
+func (j *JSONConfig) parseReleaseTimes() ([]int, error) {
+	releaseTimes := j.ReleaseTimes
+	if releaseTimes == nil {
+		releaseTimes = j.UpdateTimes
+
+		if j.UpdateTimes != nil {
+			slog.Warn("update_times is deprecated; use release_times instead")
+		}
+	} else if j.UpdateTimes != nil {
+		slog.Warn("ignoring deprecated update_times because release_times is configured")
+	}
+
+	for _, releaseTime := range releaseTimes {
+		if releaseTime < 0 || releaseTime >= 24 {
+			return nil, fmt.Errorf("invalid release time: %d", releaseTime)
+		}
+	}
+
+	return releaseTimes, nil
+}
+
+func (j *JSONConfig) parseFetchInterval() (time.Duration, error) {
+	if j.FetchIntervalMinutes < 0 {
+		return 0, fmt.Errorf("invalid fetch interval: %d minutes", j.FetchIntervalMinutes)
+	}
+
+	if j.FetchIntervalMinutes > 0 {
+		return time.Duration(j.FetchIntervalMinutes) * time.Minute, nil
+	}
+
+	return defaultFetchInterval, nil
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestJSONConfigToConfig(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		jsonConfig   JSONConfig
+		wantTimes    []int
+		wantInterval time.Duration
+		wantErr      bool
+	}{
+		{
+			name:         "defaults to hourly fetching",
+			jsonConfig:   JSONConfig{ReleaseTimes: []int{7, 16}},
+			wantTimes:    []int{7, 16},
+			wantInterval: time.Hour,
+		},
+		{
+			name:         "accepts deprecated update times",
+			jsonConfig:   JSONConfig{UpdateTimes: []int{8, 20}},
+			wantTimes:    []int{8, 20},
+			wantInterval: time.Hour,
+		},
+		{
+			name: "release times take precedence",
+			jsonConfig: JSONConfig{
+				ReleaseTimes:         []int{9},
+				UpdateTimes:          []int{10},
+				FetchIntervalMinutes: 15,
+			},
+			wantTimes:    []int{9},
+			wantInterval: 15 * time.Minute,
+		},
+		{
+			name:       "rejects invalid release time",
+			jsonConfig: JSONConfig{ReleaseTimes: []int{24}},
+			wantErr:    true,
+		},
+		{
+			name:       "rejects negative fetch interval",
+			jsonConfig: JSONConfig{FetchIntervalMinutes: -1},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := tt.jsonConfig.toConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("toConfig() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(config.ReleaseTimes, tt.wantTimes) {
+				t.Errorf("ReleaseTimes = %v, want %v", config.ReleaseTimes, tt.wantTimes)
+			}
+
+			if config.FetchInterval != tt.wantInterval {
+				t.Errorf("FetchInterval = %v, want %v", config.FetchInterval, tt.wantInterval)
+			}
+		})
+	}
+}

--- a/app/run.go
+++ b/app/run.go
@@ -41,7 +41,14 @@ func RunWithConfig(config *Config, password, dataDirPath string) error {
 	}
 	defer teardownScheduler()
 
-	fomoServer := server.New(config.BaseURL, password, config.UpdateTimes, config.Feeds, queries)
+	fomoServer := server.New(
+		config.BaseURL,
+		password,
+		config.FetchInterval,
+		config.ReleaseTimes,
+		config.Feeds,
+		queries,
+	)
 
 	slog.Info("Starting server", "url", config.BaseURL)
 

--- a/app/update.go
+++ b/app/update.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
+	"time"
 
 	"github.com/go-co-op/gocron/v2"
 
@@ -17,27 +19,23 @@ func scheduleUpdates(config *Config, queries *sqlc.Queries) (func() error, error
 		return nil, fmt.Errorf("error creating scheduler: %w", err)
 	}
 
-	var atTimes []gocron.AtTime
-
-	for _, updateTime := range config.UpdateTimes {
-		if updateTime < 0 || updateTime >= 24 {
-			return nil, fmt.Errorf("invalid update time: %d", updateTime)
-		}
-
-		atTimes = append(atTimes, gocron.NewAtTime(uint(updateTime), 0, 0))
-	}
-
-	if len(atTimes) == 0 {
+	if len(config.ReleaseTimes) == 0 {
+		slog.Info("Automatic feed fetching disabled because no release times are configured")
 		return scheduler.Shutdown, nil
 	}
 
-	slog.Info("Scheduling updates", "times", config.UpdateTimes)
+	slog.Info(
+		"Scheduling feed fetches",
+		"interval", config.FetchInterval,
+		"release_times", config.ReleaseTimes,
+	)
 
 	if _, err := scheduler.NewJob(
-		gocron.DailyJob(1, gocron.NewAtTimes(atTimes[0], atTimes[1:]...)),
+		gocron.DurationJob(config.FetchInterval),
 		gocron.NewTask(func() {
+			availableAt := nextReleaseTime(time.Now(), config.ReleaseTimes)
 			for _, f := range config.Feeds {
-				if err := feed.Fetch(context.Background(), queries, f); err != nil {
+				if err := feed.Fetch(context.Background(), queries, f, &availableAt); err != nil {
 					slog.Error("error fetching feed", "name", f.Name(), "error", err.Error())
 				}
 			}
@@ -50,4 +48,18 @@ func scheduleUpdates(config *Config, queries *sqlc.Queries) (func() error, error
 	scheduler.Start()
 
 	return scheduler.Shutdown, nil
+}
+
+func nextReleaseTime(now time.Time, releaseTimes []int) time.Time {
+	times := slices.Clone(releaseTimes)
+	slices.Sort(times)
+
+	for _, hour := range times {
+		candidate := time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, now.Location())
+		if !candidate.Before(now) {
+			return candidate
+		}
+	}
+
+	return time.Date(now.Year(), now.Month(), now.Day()+1, times[0], 0, 0, 0, now.Location())
 }

--- a/app/update_test.go
+++ b/app/update_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextReleaseTime(t *testing.T) {
+	t.Parallel()
+
+	zone := time.FixedZone("test", 2*60*60)
+	tests := []struct {
+		name  string
+		now   time.Time
+		times []int
+		want  time.Time
+	}{
+		{
+			name:  "later slot today",
+			now:   time.Date(2026, 7, 24, 8, 30, 0, 0, zone),
+			times: []int{16, 7},
+			want:  time.Date(2026, 7, 24, 16, 0, 0, 0, zone),
+		},
+		{
+			name:  "exact slot",
+			now:   time.Date(2026, 7, 24, 16, 0, 0, 0, zone),
+			times: []int{7, 16},
+			want:  time.Date(2026, 7, 24, 16, 0, 0, 0, zone),
+		},
+		{
+			name:  "first slot tomorrow",
+			now:   time.Date(2026, 7, 24, 20, 0, 0, 0, zone),
+			times: []int{16, 7},
+			want:  time.Date(2026, 7, 25, 7, 0, 0, 0, zone),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := nextReleaseTime(tt.now, tt.times); !got.Equal(tt.want) {
+				t.Errorf("nextReleaseTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
   "base_url": "http://localhost:8080",
   "port": 8080,
-  "update_times": [
+  "fetch_interval_minutes": 60,
+  "release_times": [
     7,
     16
   ],

--- a/db/availability_test.go
+++ b/db/availability_test.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cugu/fomo/db/sqlc"
+)
+
+func TestArticleAvailability(t *testing.T) { //nolint:cyclop
+	t.Parallel()
+
+	database, queries, err := DB(t.TempDir())
+	if err != nil {
+		t.Fatalf("DB() error = %v", err)
+	}
+
+	t.Cleanup(func() { _ = database.Close() })
+
+	ctx := context.Background()
+	createArticle(ctx, t, queries, "visible", sql.NullTime{})
+	createArticle(ctx, t, queries, "released", sql.NullTime{
+		Time:  time.Now().In(time.FixedZone("test", 2*60*60)).Add(-24 * time.Hour),
+		Valid: true,
+	})
+
+	hiddenID := createArticle(ctx, t, queries, "hidden", sql.NullTime{
+		Time:  time.Now().Add(24 * time.Hour),
+		Valid: true,
+	})
+
+	articles, err := queries.ListArticles(ctx, sqlc.ListArticlesParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListArticles() error = %v", err)
+	}
+
+	if len(articles) != 2 {
+		t.Fatalf("ListArticles() returned %d articles, want 2 visible articles", len(articles))
+	}
+
+	if _, err := queries.Article(ctx, hiddenID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Article(hidden) error = %v, want sql.ErrNoRows", err)
+	}
+
+	if _, err := queries.ArticleIDByGUID(ctx, "hidden"); err != nil {
+		t.Fatalf("ArticleIDByGUID(hidden) error = %v", err)
+	}
+
+	if err := queries.MarkReadAllArticles(ctx); err != nil {
+		t.Fatalf("MarkReadAllArticles() error = %v", err)
+	}
+
+	if err := queries.ReleasePendingArticles(ctx); err != nil {
+		t.Fatalf("ReleasePendingArticles() error = %v", err)
+	}
+
+	hidden, err := queries.Article(ctx, hiddenID)
+	if err != nil {
+		t.Fatalf("Article(released) error = %v", err)
+	}
+
+	if hidden.Read {
+		t.Error("hidden article was marked read before being released")
+	}
+
+	if hidden.AvailableAt.Valid {
+		t.Errorf("released article AvailableAt = %v, want NULL", hidden.AvailableAt)
+	}
+}
+
+func createArticle(
+	ctx context.Context,
+	t *testing.T,
+	queries *sqlc.Queries,
+	guid string,
+	availableAt sql.NullTime,
+) int64 {
+	t.Helper()
+
+	id, err := queries.CreateArticle(ctx, sqlc.CreateArticleParams{
+		Guid:        guid,
+		Title:       guid,
+		Body:        guid,
+		PublishedAt: time.Now(),
+		Link:        "https://example.com/" + guid,
+		Feed:        "test",
+		Details:     "",
+		AvailableAt: availableAt,
+	})
+	if err != nil {
+		t.Fatalf("CreateArticle(%q) error = %v", guid, err)
+	}
+
+	return id
+}

--- a/db/migrations/00010101000003_add_article_availability.sql
+++ b/db/migrations/00010101000003_add_article_availability.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+ALTER TABLE articles
+    ADD COLUMN available_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_articles_available_at
+    ON articles (datetime(available_at));
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_articles_available_at;
+ALTER TABLE articles DROP COLUMN available_at;

--- a/db/query.sql
+++ b/db/query.sql
@@ -1,6 +1,8 @@
 -- name: ListArticles :many
 SELECT *
 FROM articles
+WHERE available_at IS NULL
+   OR datetime(available_at) <= CURRENT_TIMESTAMP
 ORDER BY published_at DESC
 LIMIT @limit OFFSET @offset;
 
@@ -8,6 +10,7 @@ LIMIT @limit OFFSET @offset;
 SELECT *
 FROM articles
 WHERE read = FALSE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT @limit OFFSET @offset;
 
@@ -15,6 +18,7 @@ LIMIT @limit OFFSET @offset;
 SELECT *
 FROM articles
 WHERE read = TRUE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT @limit OFFSET @offset;
 
@@ -22,23 +26,26 @@ LIMIT @limit OFFSET @offset;
 SELECT *
 FROM articles
 WHERE bookmarked = TRUE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT @limit OFFSET @offset;
 
 -- name: SearchArticles :many
 SELECT *
 FROM articles
-WHERE title LIKE '%' || @query || '%'
-   OR body LIKE '%' || @query || '%'
-   OR details LIKE '%' || @query || '%'
-   OR link LIKE '%' || @query || '%'
+WHERE (title LIKE '%' || @query || '%'
+    OR body LIKE '%' || @query || '%'
+    OR details LIKE '%' || @query || '%'
+    OR link LIKE '%' || @query || '%')
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT @limit OFFSET @offset;
 
 -- name: Article :one
 SELECT *
 FROM articles
-WHERE id = @id;
+WHERE id = @id
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP);
 
 -- name: ArticleIDByGUID :one
 SELECT id
@@ -49,18 +56,19 @@ WHERE guid = @guid;
 SELECT *
 FROM articles
 WHERE read = FALSE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT 1;
 
 -- name: CreateArticle :one
-INSERT OR IGNORE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked)
-VALUES (@guid, @title, @body, @published_at, @link, @feed, @details, @read, @bookmarked)
+INSERT OR IGNORE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked, available_at)
+VALUES (@guid, @title, @body, @published_at, @link, @feed, @details, @read, @bookmarked, @available_at)
 RETURNING id;
 
 -- name: SetArticle :one
 INSERT OR
-REPLACE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked)
-VALUES (@guid, @title, @body, @published_at, @link, @feed, @details, @read, @bookmarked)
+REPLACE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked, available_at)
+VALUES (@guid, @title, @body, @published_at, @link, @feed, @details, @read, @bookmarked, @available_at)
 RETURNING id;
 
 -- name: MarkReadArticle :exec
@@ -71,7 +79,13 @@ WHERE id = @id;
 -- name: MarkReadAllArticles :exec
 UPDATE articles
 SET read = TRUE
-WHERE read = FALSE;
+WHERE read = FALSE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP);
+
+-- name: ReleasePendingArticles :exec
+UPDATE articles
+SET available_at = NULL
+WHERE available_at IS NOT NULL;
 
 -- name: BookmarkArticle :exec
 UPDATE articles

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -5,20 +5,22 @@
 package sqlc
 
 import (
+	"database/sql"
 	"time"
 )
 
 type Article struct {
-	ID          int64     `json:"id"`
-	Guid        string    `json:"guid"`
-	Title       string    `json:"title"`
-	Body        string    `json:"body"`
-	PublishedAt time.Time `json:"published_at"`
-	Link        string    `json:"link"`
-	Details     string    `json:"details"`
-	Feed        string    `json:"feed"`
-	Read        bool      `json:"read"`
-	Bookmarked  bool      `json:"bookmarked"`
+	ID          int64        `json:"id"`
+	Guid        string       `json:"guid"`
+	Title       string       `json:"title"`
+	Body        string       `json:"body"`
+	PublishedAt time.Time    `json:"published_at"`
+	Link        string       `json:"link"`
+	Details     string       `json:"details"`
+	Feed        string       `json:"feed"`
+	Read        bool         `json:"read"`
+	Bookmarked  bool         `json:"bookmarked"`
+	AvailableAt sql.NullTime `json:"available_at"`
 }
 
 type Session struct {

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -12,9 +12,10 @@ import (
 )
 
 const article = `-- name: Article :one
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
 WHERE id = ?1
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 `
 
 func (q *Queries) Article(ctx context.Context, id int64) (Article, error) {
@@ -31,6 +32,7 @@ func (q *Queries) Article(ctx context.Context, id int64) (Article, error) {
 		&i.Feed,
 		&i.Read,
 		&i.Bookmarked,
+		&i.AvailableAt,
 	)
 	return i, err
 }
@@ -77,21 +79,22 @@ func (q *Queries) CommitSession(ctx context.Context, arg CommitSessionParams) er
 }
 
 const createArticle = `-- name: CreateArticle :one
-INSERT OR IGNORE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+INSERT OR IGNORE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked, available_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
 RETURNING id
 `
 
 type CreateArticleParams struct {
-	Guid        string    `json:"guid"`
-	Title       string    `json:"title"`
-	Body        string    `json:"body"`
-	PublishedAt time.Time `json:"published_at"`
-	Link        string    `json:"link"`
-	Feed        string    `json:"feed"`
-	Details     string    `json:"details"`
-	Read        bool      `json:"read"`
-	Bookmarked  bool      `json:"bookmarked"`
+	Guid        string       `json:"guid"`
+	Title       string       `json:"title"`
+	Body        string       `json:"body"`
+	PublishedAt time.Time    `json:"published_at"`
+	Link        string       `json:"link"`
+	Feed        string       `json:"feed"`
+	Details     string       `json:"details"`
+	Read        bool         `json:"read"`
+	Bookmarked  bool         `json:"bookmarked"`
+	AvailableAt sql.NullTime `json:"available_at"`
 }
 
 func (q *Queries) CreateArticle(ctx context.Context, arg CreateArticleParams) (int64, error) {
@@ -105,6 +108,7 @@ func (q *Queries) CreateArticle(ctx context.Context, arg CreateArticleParams) (i
 		arg.Details,
 		arg.Read,
 		arg.Bookmarked,
+		arg.AvailableAt,
 	)
 	var id int64
 	err := row.Scan(&id)
@@ -136,8 +140,10 @@ func (q *Queries) FindSession(ctx context.Context, token interface{}) (Session, 
 }
 
 const listArticles = `-- name: ListArticles :many
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
+WHERE available_at IS NULL
+   OR datetime(available_at) <= CURRENT_TIMESTAMP
 ORDER BY published_at DESC
 LIMIT ?2 OFFSET ?1
 `
@@ -167,6 +173,7 @@ func (q *Queries) ListArticles(ctx context.Context, arg ListArticlesParams) ([]A
 			&i.Feed,
 			&i.Read,
 			&i.Bookmarked,
+			&i.AvailableAt,
 		); err != nil {
 			return nil, err
 		}
@@ -182,9 +189,10 @@ func (q *Queries) ListArticles(ctx context.Context, arg ListArticlesParams) ([]A
 }
 
 const listBookmarkedArticles = `-- name: ListBookmarkedArticles :many
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
 WHERE bookmarked = TRUE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT ?2 OFFSET ?1
 `
@@ -214,6 +222,7 @@ func (q *Queries) ListBookmarkedArticles(ctx context.Context, arg ListBookmarked
 			&i.Feed,
 			&i.Read,
 			&i.Bookmarked,
+			&i.AvailableAt,
 		); err != nil {
 			return nil, err
 		}
@@ -229,9 +238,10 @@ func (q *Queries) ListBookmarkedArticles(ctx context.Context, arg ListBookmarked
 }
 
 const listReadArticles = `-- name: ListReadArticles :many
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
 WHERE read = TRUE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT ?2 OFFSET ?1
 `
@@ -261,6 +271,7 @@ func (q *Queries) ListReadArticles(ctx context.Context, arg ListReadArticlesPara
 			&i.Feed,
 			&i.Read,
 			&i.Bookmarked,
+			&i.AvailableAt,
 		); err != nil {
 			return nil, err
 		}
@@ -276,9 +287,10 @@ func (q *Queries) ListReadArticles(ctx context.Context, arg ListReadArticlesPara
 }
 
 const listUnreadArticles = `-- name: ListUnreadArticles :many
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
 WHERE read = FALSE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT ?2 OFFSET ?1
 `
@@ -308,6 +320,7 @@ func (q *Queries) ListUnreadArticles(ctx context.Context, arg ListUnreadArticles
 			&i.Feed,
 			&i.Read,
 			&i.Bookmarked,
+			&i.AvailableAt,
 		); err != nil {
 			return nil, err
 		}
@@ -326,6 +339,7 @@ const markReadAllArticles = `-- name: MarkReadAllArticles :exec
 UPDATE articles
 SET read = TRUE
 WHERE read = FALSE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 `
 
 func (q *Queries) MarkReadAllArticles(ctx context.Context) error {
@@ -345,9 +359,10 @@ func (q *Queries) MarkReadArticle(ctx context.Context, id int64) error {
 }
 
 const nextUnreadArticle = `-- name: NextUnreadArticle :one
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
 WHERE read = FALSE
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT 1
 `
@@ -366,17 +381,30 @@ func (q *Queries) NextUnreadArticle(ctx context.Context) (Article, error) {
 		&i.Feed,
 		&i.Read,
 		&i.Bookmarked,
+		&i.AvailableAt,
 	)
 	return i, err
 }
 
+const releasePendingArticles = `-- name: ReleasePendingArticles :exec
+UPDATE articles
+SET available_at = NULL
+WHERE available_at IS NOT NULL
+`
+
+func (q *Queries) ReleasePendingArticles(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, releasePendingArticles)
+	return err
+}
+
 const searchArticles = `-- name: SearchArticles :many
-SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked
+SELECT id, guid, title, body, published_at, link, details, feed, read, bookmarked, available_at
 FROM articles
-WHERE title LIKE '%' || ?1 || '%'
-   OR body LIKE '%' || ?1 || '%'
-   OR details LIKE '%' || ?1 || '%'
-   OR link LIKE '%' || ?1 || '%'
+WHERE (title LIKE '%' || ?1 || '%'
+    OR body LIKE '%' || ?1 || '%'
+    OR details LIKE '%' || ?1 || '%'
+    OR link LIKE '%' || ?1 || '%')
+  AND (available_at IS NULL OR datetime(available_at) <= CURRENT_TIMESTAMP)
 ORDER BY published_at DESC
 LIMIT ?3 OFFSET ?2
 `
@@ -407,6 +435,7 @@ func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) 
 			&i.Feed,
 			&i.Read,
 			&i.Bookmarked,
+			&i.AvailableAt,
 		); err != nil {
 			return nil, err
 		}
@@ -423,21 +452,22 @@ func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) 
 
 const setArticle = `-- name: SetArticle :one
 INSERT OR
-REPLACE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+REPLACE INTO articles (guid, title, body, published_at, link, feed, details, read, bookmarked, available_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
 RETURNING id
 `
 
 type SetArticleParams struct {
-	Guid        string    `json:"guid"`
-	Title       string    `json:"title"`
-	Body        string    `json:"body"`
-	PublishedAt time.Time `json:"published_at"`
-	Link        string    `json:"link"`
-	Feed        string    `json:"feed"`
-	Details     string    `json:"details"`
-	Read        bool      `json:"read"`
-	Bookmarked  bool      `json:"bookmarked"`
+	Guid        string       `json:"guid"`
+	Title       string       `json:"title"`
+	Body        string       `json:"body"`
+	PublishedAt time.Time    `json:"published_at"`
+	Link        string       `json:"link"`
+	Feed        string       `json:"feed"`
+	Details     string       `json:"details"`
+	Read        bool         `json:"read"`
+	Bookmarked  bool         `json:"bookmarked"`
+	AvailableAt sql.NullTime `json:"available_at"`
 }
 
 func (q *Queries) SetArticle(ctx context.Context, arg SetArticleParams) (int64, error) {
@@ -451,6 +481,7 @@ func (q *Queries) SetArticle(ctx context.Context, arg SetArticleParams) (int64, 
 		arg.Details,
 		arg.Read,
 		arg.Bookmarked,
+		arg.AvailableAt,
 	)
 	var id int64
 	err := row.Scan(&id)

--- a/feed/fetch.go
+++ b/feed/fetch.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/cugu/fomo/db/sqlc"
 )
 
-func Fetch(ctx context.Context, queries *sqlc.Queries, f Feed) error {
+func Fetch(ctx context.Context, queries *sqlc.Queries, f Feed, availableAt *time.Time) error {
 	seen := func(ctx context.Context, guid string) bool {
 		if _, err := queries.ArticleIDByGUID(ctx, guid); err != nil {
 			return false
@@ -29,6 +30,11 @@ func Fetch(ctx context.Context, queries *sqlc.Queries, f Feed) error {
 			article.Body = "error: MAX BODY SIZE REACHED" + article.Body[:1_000_000]
 		}
 
+		var availability sql.NullTime
+		if availableAt != nil {
+			availability = sql.NullTime{Time: *availableAt, Valid: true}
+		}
+
 		_, err := queries.CreateArticle(ctx, sqlc.CreateArticleParams{
 			Guid:        article.Guid,
 			Title:       article.Title,
@@ -39,6 +45,7 @@ func Fetch(ctx context.Context, queries *sqlc.Queries, f Feed) error {
 			Details:     article.Details,
 			Read:        article.Read,
 			Bookmarked:  article.Bookmarked,
+			AvailableAt: availability,
 		})
 
 		// ignore duplicate entries

--- a/server/article.go
+++ b/server/article.go
@@ -173,6 +173,7 @@ func (s *Server) articleReFetch(writer http.ResponseWriter, request *http.Reques
 		Details:     updated.Details,
 		Read:        updated.Read,
 		Bookmarked:  updated.Bookmarked,
+		AvailableAt: article.AvailableAt,
 	})
 	if err != nil {
 		s.error(err.Error(), writer, request)
@@ -307,6 +308,7 @@ func (s *Server) articleUpdate(writer http.ResponseWriter, request *http.Request
 		Details:     request.FormValue("details"),
 		Read:        article.Read,
 		Bookmarked:  article.Bookmarked,
+		AvailableAt: article.AvailableAt,
 	})
 	if err != nil {
 		s.error(err.Error(), writer, request)

--- a/server/fetch.go
+++ b/server/fetch.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,8 +17,13 @@ import (
 func (s *Server) fetchFeeds(writer http.ResponseWriter, request *http.Request) {
 	var errs []error
 
+	if err := s.queries.ReleasePendingArticles(request.Context()); err != nil {
+		s.error(err.Error(), writer, request)
+		return
+	}
+
 	for _, f := range s.feeds {
-		errs = append(errs, feed.Fetch(request.Context(), s.queries, f))
+		errs = append(errs, feed.Fetch(request.Context(), s.queries, f, nil))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -59,6 +65,7 @@ func (s *Server) addArticle(writer http.ResponseWriter, request *http.Request) {
 		Details:     targetURL.Hostname(),
 		Read:        false,
 		Bookmarked:  false,
+		AvailableAt: sql.NullTime{},
 	})
 	if err != nil {
 		s.error(err.Error(), writer, request)

--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,8 @@ import (
 type Server struct {
 	baseURL        string
 	password       string
-	updateTimes    []int
+	fetchInterval  time.Duration
+	releaseTimes   []int
 	queries        *sqlc.Queries
 	feeds          []feed.Feed
 	sessionManager *scs.SessionManager
@@ -28,7 +29,8 @@ type Server struct {
 func New(
 	baseURL string,
 	password string,
-	updateTimes []int,
+	fetchInterval time.Duration,
+	releaseTimes []int,
 	feeds []feed.Feed,
 	queries *sqlc.Queries,
 ) *Server {
@@ -39,7 +41,8 @@ func New(
 	return &Server{
 		baseURL:        baseURL,
 		password:       password,
-		updateTimes:    updateTimes,
+		fetchInterval:  fetchInterval,
+		releaseTimes:   releaseTimes,
 		queries:        queries,
 		feeds:          feeds,
 		sessionManager: sessionManager,
@@ -64,7 +67,9 @@ func (s *Server) template(writer http.ResponseWriter, title string, data map[str
 	data["BaseURL"] = s.baseURL
 
 	zone, _ := time.Now().Zone()
-	data["UpdateTimes"] = fmt.Sprintf("%s (%s)", formatTimes(s.updateTimes), zone)
+	data["FetchInterval"] = s.fetchInterval
+	data["ReleaseTimes"] = fmt.Sprintf("%s (%s)", formatTimes(s.releaseTimes), zone)
+	data["AutomaticFetchEnabled"] = len(s.releaseTimes) > 0
 
 	if err := s.templates.ExecuteTemplate(writer, title, data); err != nil {
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
@@ -78,6 +83,7 @@ func formatTimes(updateTimes []int) string {
 		return ""
 	}
 
+	updateTimes = slices.Clone(updateTimes)
 	slices.Sort(updateTimes)
 
 	var times []string

--- a/ui/base.gotmpl
+++ b/ui/base.gotmpl
@@ -26,7 +26,11 @@
         </h1>
     </a>
     <small class="subtitle">
-        Feeds are updated at {{ .UpdateTimes }}.
+        {{ if .AutomaticFetchEnabled }}
+            Feeds are fetched every {{ .FetchInterval }}; articles are released at {{ .ReleaseTimes }}.
+        {{ else }}
+            Automatic feed fetching is disabled.
+        {{ end }}
     </small>
 {{ end }}
 


### PR DESCRIPTION
## Summary

- fetch feeds on a configurable interval, defaulting to 60 minutes
- keep automatically fetched articles hidden until the next configured release time
- retain `update_times` as a deprecated alias for `release_times`
- make manual feed fetches and URL ingestion immediately visible

## Why

Feed fetching and article visibility were previously controlled by the same `update_times` schedule. This meant feeds could not be polled more frequently without also exposing articles more frequently. The new `available_at` field separates ingestion from release while preserving the existing scheduled-reading behavior.

## Impact

Existing articles remain visible after migration. Existing configurations continue to work, while new installations can combine `fetch_interval_minutes` with `release_times`. With no release times configured, automatic feed fetching stays disabled.

## Validation

- `make generate`
- `make lint`
- `make test`
- `git diff --check`
